### PR TITLE
Filter null constraints in AddConstraints()

### DIFF
--- a/Cirrious.FluentLayout/FluentLayoutExtensions.cs
+++ b/Cirrious.FluentLayout/FluentLayoutExtensions.cs
@@ -84,6 +84,7 @@ namespace Cirrious.FluentLayouts.Touch
         public static void AddConstraints(this UIView view, params FluentLayout[] fluentLayouts)
         {
             view.AddConstraints(fluentLayouts
+                                    .Where(fluent => fluent != null)
                                     .SelectMany(fluent => fluent.ToLayoutConstraints())
                                     .ToArray());
         }
@@ -91,6 +92,7 @@ namespace Cirrious.FluentLayouts.Touch
         public static void AddConstraints(this UIView view, IEnumerable<FluentLayout> fluentLayouts)
         {
             view.AddConstraints(fluentLayouts
+                                    .Where(fluent => fluent != null)
                                     .SelectMany(fluent => fluent.ToLayoutConstraints())
                                     .ToArray());
         }


### PR DESCRIPTION
I often find I have optional constraints (left vs right anchoring, size switches, optional UI elements, etc.) Especially in table view cells. I changed the above code to allow me to write layouts like so:

```
        View.AddConstraints(
            viewHasHeader ? TableViewControl.Below(HeaderContainerView) : null,
            TableViewControl.AtLeftOf(View),
            TableViewControl.AtRightOf(View),
            TableViewControl.AtBottomOf(View)
        );
```

This change is so I don't have to have lists of optional constraints (i.e. separate calls to AddConstraints() ) after the core set of constraints - that are then separated by many lines of code and if blocks. I was also debating adding my own custom constraints - which when they were not needed would return null. Something like BelowIfExists(this UIView view, UIView previous, float margin = 0f)

Not sure if the allowing of nulls in lists of constraints fits the rest of the design though :)
