### PR TITLE
Fix to set constraint priority

### DIFF
--- a/Cirrious.FluentLayout/FluentLayout.cs
+++ b/Cirrious.FluentLayout/FluentLayout.cs
@@ -151,7 +151,7 @@ namespace Cirrious.FluentLayouts.Touch
 
         public IEnumerable<NSLayoutConstraint> ToLayoutConstraints()
         {
-            yield return NSLayoutConstraint.Create(
+            var constraint = NSLayoutConstraint.Create(
                 View,
                 Attribute,
                 Relation,
@@ -159,6 +159,11 @@ namespace Cirrious.FluentLayouts.Touch
                 SecondAttribute,
                 Multiplier,
                 Constant);
+            
+            if (Priority != default(float))
+                constraint.Priority = Priority;
+                
+            yield return constraint;
         }
     }
 }


### PR DESCRIPTION
FluentLayout class lets you set the constraint priority with SetPriority method, but the priority was not being assigned to the NSLayoutConstraint in ToLayoutConstraints.
