### PR TITLE
Remove nfloat overloads in favor of default(nfloat) defaults

### DIFF
--- a/Cirrious.FluentLayout/FluentLayout.cs
+++ b/Cirrious.FluentLayout/FluentLayout.cs
@@ -33,7 +33,7 @@ namespace Cirrious.FluentLayouts.Touch
         public FluentLayout(UIView view,
                             NSLayoutAttribute attribute,
                             NSLayoutRelation relation,
-                            nfloat constant)
+							nfloat constant = default(nfloat))
         {
             View = view;
             Attribute = attribute;

--- a/Cirrious.FluentLayout/UIViewAndLayoutAttribute.cs
+++ b/Cirrious.FluentLayout/UIViewAndLayoutAttribute.cs
@@ -21,32 +21,17 @@ namespace Cirrious.FluentLayouts.Touch
         public UIView View { get; private set; }
         public NSLayoutAttribute Attribute { get; private set; }
 
-		public FluentLayout EqualTo()
-		{
-			return EqualTo(0);
-		}
-
-        public FluentLayout EqualTo(nfloat constant)
+		public FluentLayout EqualTo(nfloat constant = default(nfloat))
         {
             return new FluentLayout(View, Attribute, NSLayoutRelation.Equal, constant);
         }
 
-		public FluentLayout GreaterThanOrEqualTo()
-		{
-			return GreaterThanOrEqualTo(0);
-		}
-
-        public FluentLayout GreaterThanOrEqualTo(nfloat constant)
+		public FluentLayout GreaterThanOrEqualTo(nfloat constant = default(nfloat))
         {
             return new FluentLayout(View, Attribute, NSLayoutRelation.GreaterThanOrEqual, constant);
         }
 
-		public FluentLayout LessThanOrEqualTo()
-		{
-			return LessThanOrEqualTo(0);
-		}
-
-        public FluentLayout LessThanOrEqualTo(nfloat constant)
+		public FluentLayout LessThanOrEqualTo(nfloat constant = default(nfloat))
         {
             return new FluentLayout(View, Attribute, NSLayoutRelation.LessThanOrEqual, constant);
         }

--- a/QuickLayout.Touch/Info.plist
+++ b/QuickLayout.Touch/Info.plist
@@ -13,7 +13,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>3.2</string>
+	<string>7.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>QuickLayout</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
When I submitted #12 yesterday I spaced on the fact that I could just use `default(nfloat)` instead of creating those ugly overloads
